### PR TITLE
Add support for multiple recaptchas per page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ docs/_build/
 target/
 *.sqlite3
 pep8.txt
+# Rope
+.ropeproject/
+# Vim
+*.swp

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The original django-recaptcha project is located at the following location:
  - Uses the fallback option for browsers without JavaScript
  - Easy to add to a Form via a FormField
  - Works similar to django-recaptcha 
+ - Supports multiple recaptchas per page (requires JavaScript)
  - Working demo projects
  - Works with Python 2.7 and 3.4
 
@@ -63,10 +64,13 @@ Add the field to a form that you want to protect.
 	    captcha = NoReCaptchaField()
 	    
 
-Add Google's JavaScript library to your base template or elsewhere, so it is
-available on the page containing the django form.
+Add this template tag to your base template or elsewhere, so that Google's JavaScript library is available on the page containing the django form.
 
-    <script src="https://www.google.com/recaptcha/api.js" async defer></script>	    
+    # For a single recaptcha on a page:
+    {% include 'nocaptcha_recaptcha/script_include.html' %}
+
+    # For multiple recaptchas on the same page:
+    {% include 'nocaptcha_recaptcha/script_include.html' with multiple_recaptcha=True %}
 
 
 (optional)

--- a/nocaptcha_recaptcha/templates/nocaptcha_recaptcha/script_include.html
+++ b/nocaptcha_recaptcha/templates/nocaptcha_recaptcha/script_include.html
@@ -1,0 +1,24 @@
+<script src="https://www.google.com/recaptcha/api.js{% if multiple_recaptcha %}?onload=recaptchaCallBack&amp;render=explicit{% endif %}" async defer></script>
+{% if multiple_recaptcha %}
+<script type="text/javascript">
+function remove_noscript(el) {
+    {# If JavaScript is enabled, remove the sibling <noscript> since its child <textarea> will contain duplicate ids in the DOM #}
+    while (el.nodeName.toLowerCase() != "noscript") {
+        el = el.nextSibling;
+        if (el == null) break;
+    }
+    if (el) el.parentNode.removeChild(el);
+}
+function render_captcha(el, i) {
+    remove_noscript(el);
+    if ( !el.hasAttribute("id") ) el.id = "nocaptcha-recaptcha-" + (i + 1);
+    grecaptcha.render(el.id, {"sitekey": el.getAttribute("data-sitekey")});
+}
+function recaptchaCallBack() {
+    var captcha_divs = document.getElementsByClassName("g-recaptcha");
+    for(var n = 0; n < captcha_divs.length; n++) {
+        render_captcha(captcha_divs[n], n);
+    }
+}
+</script>
+{% endif %}


### PR DESCRIPTION
Google's API only adds a reCAPTCHA to the first element it finds, by default.  The new API does provide a way to add a reCAPTCHA to multiple elements on the same page using JavaScript.  This is useful, for example, when a page contains multiple forms that might be shown or hidden depending on user interaction.  I recently needed to modify django-nocaptcha-recaptcha to do this.  Here is the modified code to support multiple recaptchas per page, in case you would like to merge it back into your project.  It includes a documentation update (but no added Python tests, since the changes are purely to JavaScript and not to the Python code).  Thanks for the work you put in to this app!
