### PR TITLE
Remove usage of pkg_resources

### DIFF
--- a/nocaptcha_recaptcha/__init__.py
+++ b/nocaptcha_recaptcha/__init__.py
@@ -1,6 +1,4 @@
-import pkg_resources
-
-__version__ = pkg_resources.require("django-nocaptcha-recaptcha")[0].version
+__version__ = '0.0.18'
 
 from .fields import NoReCaptchaField
 from .widgets import NoReCaptchaWidget


### PR DESCRIPTION
Using `pkg_resources` can create some problems as it may not be accessible depending on your setup, i.e. App Engine. I think it's safe just to hardcode the version number and change it there as well.

I tried to use `__version__` in `setup.py` but as `__init__` is importing some classes, it crashes. I don't think the duplication is that awful though.